### PR TITLE
add crash reporter with Github link generator

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,6 +13,12 @@ body:
     validations:
       required: true
   - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: Shell
+  - type: textarea
     attributes:
       label: How to reproduce
       description: Steps to reproduce the behavior

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,7 @@ name = "benchie"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytesize",
  "cargo-husky",
  "chrono",
  "clap",
@@ -37,7 +38,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "sysinfo",
  "tempfile",
+ "url",
 ]
 
 [[package]]
@@ -57,6 +60,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "bytesize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
 
 [[package]]
 name = "cargo-husky"
@@ -147,6 +156,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,12 +229,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -196,6 +272,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -252,10 +339,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "num-integer"
@@ -275,6 +386,22 @@ checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "os_str_bytes"
@@ -306,6 +433,12 @@ dependencies = [
  "smallvec",
  "winapi",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "proc-macro-error"
@@ -347,6 +480,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
 ]
 
 [[package]]
@@ -470,6 +627,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.23.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eea2ed6847da2e0c7289f72cb4f285f0bd704694ca067d32be811b2a45ea858"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +682,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +722,18 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ serde_json = "1.0"
 chrono = {version = "0.4", features = ["serde"]}
 anyhow = "1.0"
 cli-table = "0.4"
+sysinfo = "0.23"
+bytesize = "1.1.0"
+url = "2.2.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/crash_report.rs
+++ b/src/crash_report.rs
@@ -1,0 +1,243 @@
+use bytesize::ByteSize;
+use std::env;
+use std::fmt::{Display, Formatter};
+use std::panic;
+use sysinfo::{System, SystemExt};
+use url::Url;
+
+struct CrashReport {
+    panic_log: String,
+    total_memory: ByteSize,
+    used_memory: ByteSize,
+    total_swap: ByteSize,
+    used_swap: ByteSize,
+    cores: usize,
+    os: String,
+    os_family: String,
+    os_version: String,
+    kernel_version: String,
+    arch: String,
+    benchie_version: String,
+}
+
+const GITHUB_NEW_ISSUE_URL: &str = "https://github.com/benchie-io/benchie/issues/new";
+const MAX_URL_LENGTH: usize = 4000;
+
+impl CrashReport {
+    fn new(panic_info: impl Display) -> Self {
+        // Please note that we use "new_all" to ensure that all list of
+        // components, network interfaces, disks and users are already
+        // filled!
+        let mut system = System::new_all();
+        // First we update all information of our `System` struct.
+        system.refresh_all();
+
+        Self {
+            panic_log: format!("{}", panic_info),
+            total_memory: ByteSize::kb(system.total_memory()),
+            used_memory: ByteSize::kb(system.used_memory()),
+            total_swap: ByteSize::kb(system.total_swap()),
+            used_swap: ByteSize::kb(system.used_swap()),
+            cores: system.processors().len(),
+            os: env::consts::OS.to_owned(),
+            os_family: env::consts::FAMILY.to_owned(),
+            os_version: system.os_version().unwrap_or_else(|| "unknown".to_owned()),
+            kernel_version: system
+                .kernel_version()
+                .unwrap_or_else(|| "unknown".to_owned()),
+            arch: env::consts::ARCH.to_owned(),
+            benchie_version: option_env!("CARGO_PKG_VERSION")
+                .unwrap_or("not found")
+                .to_owned(),
+        }
+    }
+
+    fn without_panic_info() -> Self {
+        Self::new("<!-- Please copy and paste any relevant log output. -->".to_string())
+    }
+}
+
+impl Display for CrashReport {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Hi benchie Team! My benchie program just crashed. This is the report:
+
+## Bug description
+<!-- A clear and concise description of what the bug is. -->
+
+## Relevant log output
+```
+{}
+```
+
+## How to reproduce
+<!-- Steps to reproduce the behavior -->
+
+## Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
+
+## benchie information
+<!-- Your benchie command, .benchie/data.json,... -->
+
+## Environment & Setup
+| Name | Value |
+|---|--|
+| OS | {} |
+| OS family | {} |
+| OS version | {} |
+| kernel version | {} |
+| Arch | {} |
+| # cores | {} |
+| total memory | {} |
+| used memory | {} |
+| total swap | {} |
+| used swap | {} |
+
+## benchie Version
+`{}`
+",
+            self.panic_log,
+            self.os,
+            self.os_family,
+            self.os_version,
+            self.kernel_version,
+            self.arch,
+            self.cores,
+            self.total_memory,
+            self.used_memory,
+            self.total_swap,
+            self.used_swap,
+            self.benchie_version
+        )
+    }
+}
+
+fn build_github_issue_url(panic_info: &impl Display) -> String {
+    let mut base_url = Url::parse(GITHUB_NEW_ISSUE_URL).expect("Github issues URL is valid");
+
+    let url = base_url
+        .query_pairs_mut()
+        .append_pair("labels", "bug")
+        .append_pair("body", &format!("{}", CrashReport::new(panic_info)))
+        .finish()
+        .to_string();
+
+    if url.len() < MAX_URL_LENGTH {
+        url
+    } else {
+        base_url
+            .query_pairs_mut()
+            .clear()
+            .append_pair("labels", "bug")
+            .append_pair("body", &format!("{}", CrashReport::without_panic_info()))
+            .finish()
+            .to_string()
+    }
+}
+
+fn build_panic_message(panic_info: &impl Display) -> String {
+    let url = build_github_issue_url(panic_info);
+
+    format!(
+        "This is a non-recoverable error which probably happens when benchie has a panic.
+{}
+
+{}
+
+If you want the benchie team to look into it, please open the link above 🙏
+To increase the chance of success, please post your schema and a snippet of
+how you used benchie in the issue.
+",
+        panic_info, url
+    )
+}
+
+pub fn initialize_crash_reporter() {
+    panic::set_hook(Box::new(|panic_info| {
+        eprintln!("{}", build_panic_message(panic_info))
+    }))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn panic_message_should_always_contain_panic_info() {
+        let msg = build_panic_message(&big_panic_info());
+
+        assert!(
+            msg.contains(&big_panic_info()),
+            "message should contain a panic info, even if it's large"
+        );
+        assert!(
+            msg.contains(GITHUB_NEW_ISSUE_URL),
+            "should contain Github URL"
+        );
+
+        let msg = build_panic_message(&small_panic_info());
+
+        assert!(
+            msg.contains(&small_panic_info()),
+            "message should contain a panic info, even if it's large"
+        );
+        assert!(
+            msg.contains(GITHUB_NEW_ISSUE_URL),
+            "should contain Github URL"
+        )
+    }
+
+    #[test]
+    fn github_urls_should_not_exceed_maximum_url_length() {
+        let small_url = build_github_issue_url(&small_panic_info());
+        let big_url = build_github_issue_url(&big_panic_info());
+
+        assert!(
+            small_url.len() < MAX_URL_LENGTH,
+            "url should not exceed maximum URL length allowed in modern browsers"
+        );
+        assert!(
+            big_url.len() < MAX_URL_LENGTH,
+            "url should not exceed maximum URL length allowed in modern browsers"
+        );
+    }
+
+    #[test]
+    fn panic_info_can_be_omitted_in_github_url_if_too_long() {
+        let small_url = build_github_issue_url(&small_panic_info());
+        let big_url = build_github_issue_url(&big_panic_info());
+
+        let small_url = Url::parse(&small_url).unwrap();
+        let (_, body) = small_url
+            .query_pairs()
+            .find(|(key, _)| key == "body")
+            .unwrap();
+
+        assert!(
+            body.contains(&small_panic_info()),
+            "small url does contain panic info message"
+        );
+
+        let big_url = Url::parse(&big_url).unwrap();
+        let (_, body) = big_url
+            .query_pairs()
+            .find(|(key, _)| key == "body")
+            .unwrap();
+
+        assert!(
+            !body.contains(&big_panic_info()),
+            "big url does not contain panic info message"
+        );
+    }
+
+    fn big_panic_info() -> String {
+        (1..1000)
+            .into_iter()
+            .fold(String::new(), |res, _| res + " Hello World!")
+    }
+
+    fn small_panic_info() -> String {
+        "Hello World!".to_string()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 mod benchmark;
+mod crash_report;
 mod show;
 mod storage;
 
 pub use benchmark::benchmark;
+pub use crash_report::initialize_crash_reporter;
 pub use show::show;
 pub use storage::{append_benchmark, load_all_benchmarks, Benchmark};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,13 @@
 use anyhow::Result;
-use benchie::benchmark;
 use benchie::show;
+use benchie::{benchmark, initialize_crash_reporter};
 use std::env;
 
 mod cli;
 
 fn main() -> Result<()> {
+    initialize_crash_reporter();
+
     let raw_args: Vec<_> = env::args_os().collect();
     let args = cli::parse_arguments(&raw_args)?;
 


### PR DESCRIPTION
Print a help message in the CLI, if benchie crashes due to a panic. In the help message, a Github link is included, which can be used to generate an issue in this repository.

Here is an example link you can check out: [https://github.com/benchie-io/benchie/issues/new?labels=bug&body=Hi+benchie+Team%21+My+benchie+program+just+crashed.+This+is+the+report%3A%0A%0A%23%23+Bug+description%0A%3C%21--+A+clear+and+concise+description+of+what+the+bug+is.+--%3E%0A%0A%23%23+Relevant+log+output%0A%60%60%60%0Apanicked+at+%27called+%60Result%3A%3Aunwrap%28%29%60+on+an+%60Err%60+value%3A+Os+%7B+code%3A+2%2C+kind%3A+NotFound%2C+message%3A+%22No+such+file+or+directory%22+%7D%27%2C+src%2Fstorage.rs%3A53%3A65%0A%60%60%60%0A%0A%23%23+How+to+reproduce%0A%3C%21--+Steps+to+reproduce+the+behavior+--%3E%0A%0A%23%23+Expected+behavior%0A%3C%21--+A+clear+and+concise+description+of+what+you+expected+to+happen.+--%3E%0A%0A%23%23+benchie+information%0A%3C%21--+Your+benchie+command%2C+.benchie%2Fdata.json%2C...+--%3E%0A%0A%23%23+Environment+%26+Setup%0A%7C+Name+%7C+Value+%7C%0A%7C---%7C--%7C%0A%7C+OS+%7C+macos+%7C%0A%7C+OS+family+%7C+unix+%7C%0A%7C+OS+version+%7C+12.3.1+%7C%0A%7C+kernel+version+%7C+21.4.0+%7C%0A%7C+Arch+%7C+aarch64+%7C%0A%7C+%23+cores+%7C+8+%7C%0A%7C+total+memory+%7C+17.2+GB+%7C%0A%7C+used+memory+%7C+16.9+GB+%7C%0A%7C+total+swap+%7C+1073.7+MB+%7C%0A%7C+used+swap+%7C+64.5+MB+%7C%0A%0A%23%23+benchie+Version%0A%600.1.0%60%0A](https://github.com/benchie-io/benchie/issues/new?labels=bug&body=Hi+benchie+Team%21+My+benchie+program+just+crashed.+This+is+the+report%3A%0A%0A%23%23+Bug+description%0A%3C%21--+A+clear+and+concise+description+of+what+the+bug+is.+--%3E%0A%0A%23%23+Relevant+log+output%0A%60%60%60%0Apanicked+at+%27called+%60Result%3A%3Aunwrap%28%29%60+on+an+%60Err%60+value%3A+Os+%7B+code%3A+2%2C+kind%3A+NotFound%2C+message%3A+%22No+such+file+or+directory%22+%7D%27%2C+src%2Fstorage.rs%3A53%3A65%0A%60%60%60%0A%0A%23%23+How+to+reproduce%0A%3C%21--+Steps+to+reproduce+the+behavior+--%3E%0A%0A%23%23+Expected+behavior%0A%3C%21--+A+clear+and+concise+description+of+what+you+expected+to+happen.+--%3E%0A%0A%23%23+benchie+information%0A%3C%21--+Your+benchie+command%2C+.benchie%2Fdata.json%2C...+--%3E%0A%0A%23%23+Environment+%26+Setup%0A%7C+Name+%7C+Value+%7C%0A%7C---%7C--%7C%0A%7C+OS+%7C+macos+%7C%0A%7C+OS+family+%7C+unix+%7C%0A%7C+OS+version+%7C+12.3.1+%7C%0A%7C+kernel+version+%7C+21.4.0+%7C%0A%7C+Arch+%7C+aarch64+%7C%0A%7C+%23+cores+%7C+8+%7C%0A%7C+total+memory+%7C+17.2+GB+%7C%0A%7C+used+memory+%7C+16.9+GB+%7C%0A%7C+total+swap+%7C+1073.7+MB+%7C%0A%7C+used+swap+%7C+64.5+MB+%7C%0A%0A%23%23+benchie+Version%0A%600.1.0%60%0A)
